### PR TITLE
Attempt macOS 11 "support" via local machine builds (pyproject.toml)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicksocket"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Nick Benson <nickjbenson@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["maturin"]
+build-backend = "maturin"


### PR DESCRIPTION
~Adds a macos-11 builder to support the latest macOS (Big Sur).~

macOS 11 (Big Sur) support appears to be more difficult than expected because macos-11 runners are not publicly available yet. Instead, trying to figure out how to get local machines running macOS 11 to just build the necessary wheel via their own rust/maturin workflow. (This probably requires rust to be installed on the local machine, which is not ideal, but at least reliable)